### PR TITLE
Add max_participants = 4 in activity.info

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -4,6 +4,7 @@ bundle_id = org.laptop.Pippy
 exec = sugar-activity pippy_app.PippyActivity
 icon = activity-icon
 activity_version = 70
+max_participants = 4
 mime_types = text/x-python;pickle/groupthink-pippy
 show_launcher = yes
 license = GPLv2+


### PR DESCRIPTION
Without this property max_participant user cannot invite other users to join a shared activity
if condition in jarabe.view.buddymenu.py #L186 is not satisfied wihout this property
link --> https://goo.gl/SoqYZW