### PR TITLE
Fix AttributeError on missing 'leader' attribute

### DIFF
--- a/pippy_app.py
+++ b/pippy_app.py
@@ -510,14 +510,14 @@ class PippyActivity(ViewSourceActivity):
             self._select_func_cb(path)
 
     def _add_source_cb(self, button, force=False, editor_id=None):
-        if self._collab.props.leader or force:
+        if self._collab._leader or force:
             if editor_id is None:
                 editor_id = str(uuid.uuid1())
             self._source_tabs.add_tab(editor_id=editor_id)
             self.session_data.append(None)
             self._source_tabs.get_nth_page(-1).show_all()
             self._source_tabs.get_text_view().grab_focus()
-            if self._collab.props.leader:
+            if self._collab._leader:
                 self._collab.post(dict(
                     action='add-source',
                     editor_id=editor_id))
@@ -528,7 +528,7 @@ class PippyActivity(ViewSourceActivity):
 
     def __message_cb(self, collab, buddy, msg):
         action = msg.get('action')
-        if action == 'add-source-request' and self._collab.props.leader:
+        if action == 'add-source-request' and self._collab._leader:
             self._add_source_cb(None, force=True)
         elif action == 'add-source':
             self._add_source_cb(

--- a/texteditor.py
+++ b/texteditor.py
@@ -77,7 +77,7 @@ class TextBufferCollaberizer(object):
         self._buffer.connect('delete-range', self.__text_buffer_deleted_cb)
         self._buffer.set_text('')
 
-        if not self._collab.props.leader:
+        if not self._collab._leader:
             # We must be joining an activity and just made the buffer
             self._collab.post(dict(
                 action='init_request',


### PR DESCRIPTION
Without this change, I get the following crash when I try to launch Pippy outside from Sugar shell:
```
Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 220, in <module>
    main()
  File "/usr/bin/sugar-activity", line 215, in main
    instance = create_activity_instance(activity_constructor, activity_handle)
  File "/usr/bin/sugar-activity", line 48, in create_activity_instance
    activity = constructor(handle)
  File "/usr/share/sugar/activities/Pippy-70/pippy_app.py", line 160, in __init__
    self.set_canvas(self.initialize_display())
  File "/usr/share/sugar/activities/Pippy-70/pippy_app.py", line 387, in initialize_display
    self._source_tabs.add_tab()  # New instance, ergo empty tab
  File "/usr/share/sugar/activities/Pippy-70/notebook.py", line 209, in add_tab
    buffer_text, editor_id, self._collab)
  File "/usr/share/sugar/activities/Pippy-70/notebook.py", line 151, in __init__
    text_buffer, editor_id, collab)
  File "/usr/share/sugar/activities/Pippy-70/texteditor.py", line 80, in __init__
    if not self._collab.props.leader:
AttributeError: 'gi._gobject.GProps' object has no attribute 'leader'
```