### PR TITLE
Fix setting focus on empty page

### DIFF
--- a/notebook.py
+++ b/notebook.py
@@ -315,7 +315,10 @@ class SourceNotebook(AddNotebook):
         return text_buffer
 
     def get_text_view(self):
-        tab = self.get_nth_page(self.get_current_page()).get_children()
+        page = self.get_current_page()
+        if page == -1:
+            return None
+        tab = self.get_nth_page(page).get_children()
         text_view = tab[0]
         return text_view
 

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -165,8 +165,9 @@ class PippyActivity(ViewSourceActivity):
         def focus():
             """ Enforce focus for the text view once. """
             widget = self.get_toplevel().get_focus()
-            if widget is None:
-                self._source_tabs.get_text_view().grab_focus()
+            textview = self._source_tabs.get_text_view()
+            if widget is None and textview is not None:
+                textview.grab_focus()
                 return True
             return False
         GLib.timeout_add(100, focus)


### PR DESCRIPTION
The first time the Activity is opened, there are no pages in the GtkNotebook and therefore there is no
widget to set focus to. We need to consider this scenario to avoid errors.