### PR TITLE
Fix no source tab on resume of empty file

### DIFF
--- a/pippy_app.py
+++ b/pippy_app.py
@@ -1094,6 +1094,8 @@ class PippyActivity(ViewSourceActivity):
         session_list = []
         app_temp = os.path.join(self.get_activity_root(), 'instance')
         tmpfile = os.path.join(app_temp, 'pippy-tempfile-storing.py')
+        if not self.session_data:
+            self.session_data.append(None)
         for zipdata, content in zip(zipped_data, self.session_data):
             _logger.debug('Session data %r', content)
             name, python_code, path, modified, editor_id = zipdata
@@ -1287,8 +1289,12 @@ class PippyActivity(ViewSourceActivity):
                     self.session_data.append(content)
                     self._loaded_session.append([name, python_code, path])
 
-        for name, content, path in self._loaded_session:
-            self._source_tabs.add_tab(name, content, path)
+        # Create tabs from the datastore, else add a blank tab
+        if self._loaded_session:
+            for name, content, path in self._loaded_session:
+                self._source_tabs.add_tab(name, content, path)
+        else:
+            self._source_tabs.add_tab()
 
 # TEMPLATES AND INLINE FILES
 ACTIVITY_INFO_TEMPLATE = '''


### PR DESCRIPTION
The changes in read_file() adds an empty tab if there isn't any data
loaded from the datastore to create tabs.

Also, when one made changes to the tab now present after the fix,
it did not save. This is because the session data was empty after
reading the empty source file from the datastore.
If the session data is empty, the for loop that iterates through the
zip in write_file() is skipped.

Fix in write_file() appends a None object to the
session data if it is empty.

Reproduce:
Start Pippy -> Stop Pippy -> Resume Pippy -> Source tab is missing

Fixes #67