### PR TITLE
Fix pygame full screen issue in some examples

### DIFF
--- a/data/en/graphics/bounce
+++ b/data/en/graphics/bounce
@@ -22,7 +22,7 @@ pygame.mouse.set_visible(False)
 
 # create the window and keep track of the surface
 # for drawing into
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # ask for screen's width and height
 size = width, height = screen.get_size()

--- a/data/en/graphics/camera
+++ b/data/en/graphics/camera
@@ -21,7 +21,7 @@ pygame.mouse.set_visible(False)
 
 # create the pygame window and return a Surface object for
 # drawing in that window.
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # grab a frame from camera to file
 pipeline = Gst.parse_launch('v4l2src ! videoconvert ! jpegenc ! filesink location=/tmp/pippypic.jpg')

--- a/data/en/graphics/lines
+++ b/data/en/graphics/lines
@@ -15,7 +15,7 @@ pygame.mouse.set_visible(False)
 
 # create the window and keep track of the surface
 # for drawing into
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # ask for screen's width and height
 size = width, height = screen.get_size()

--- a/data/en/graphics/physics
+++ b/data/en/graphics/physics
@@ -9,7 +9,7 @@ from pippy import physics
 
 # initialize pygame first thing
 pygame.init()
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # set up the physics world (instance of Elements)
 world = physics.Elements(screen.get_size())

--- a/data/en/graphics/pong
+++ b/data/en/graphics/pong
@@ -16,7 +16,7 @@ pygame.init()
 
 # create the window and keep track of the surface
 # for drawing into
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # ask for screen's width and height
 size = width, height = screen.get_size()

--- a/data/en/graphics/snow
+++ b/data/en/graphics/snow
@@ -11,7 +11,7 @@ pygame.init()
 
 # create the window and keep track of the surface
 # for drawing into
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # ask for screen's width and height
 width, height = screen.get_size()

--- a/data/en/graphics/tree
+++ b/data/en/graphics/tree
@@ -12,7 +12,7 @@ pygame.init()
 
 # create the window and keep track of the surface
 # for drawing into
-screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+screen = pygame.display.set_mode((0, 0), pygame.NOFRAME | pygame.FULLSCREEN)
 
 # ask for screen's width and height
 width, height = screen.get_size()


### PR DESCRIPTION
Specifically in the `tree` example, nothing except the background color (black in this case) is displayed, because the screen is not being updated every frame, unlike other examples. This is probably related to [this](https://github.com/pygame/pygame/issues/2538) pygame issue as it happens if you run the example even without pippy. Although it doesn't happen for everyone, I couldn't reproduce it on Fedora 38 KDE, but it happens on Fedora 38 Gnome.

The fix is to include the `pygame.NOFRAME` flag before the fullscreen flag.