### PR TITLE
fork_command_full() removal with drop of Vte- 2.90

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -171,16 +171,18 @@ class VteActivity(ViewSourceActivity):
         # the 'sleep 1' works around a bug with the command dying before
         # the vte widget manages to snarf the last bits of its output
         logging.error(bundle_path)
-
-        self._pid = self._vte.fork_command_full(
+        
+        self._pid = self._vte.spawn_async( 
             Vte.PtyFlags.DEFAULT,
             bundle_path,
             ['/bin/sh', '-c', 'python3 %s/pippy_app.py; sleep 1' % bundle_path],
             ["PYTHONPATH=%s/library" % bundle_path],
             GLib.SpawnFlags.DO_NOT_REAP_CHILD,
             None,
-            None,)
-
+            None,
+            -1,  # no timeout
+            None,  
+            None)  
     def _on_copy_clicked_cb(self, widget):
         if self._vte.get_has_selection():
             self._vte.copy_clipboard()


### PR DESCRIPTION
The fork_command_full() method was removed in Vte 2.91. An AttributeError will emerge since the method no longer exists. 
 https://lazka.github.io/pgi-docs/Vte-2.91/classes/Terminal.html