### PR TITLE
Eliminate jarabe Dependency by Replacing generate_unique_id with uuid (Fixes #64)

### DIFF
--- a/pippy_app.py
+++ b/pippy_app.py
@@ -74,7 +74,6 @@ from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.toolbarbox import ToolbarBox
 from sugar3.activity.widgets import ActivityToolbarButton
 
-from jarabe.view.customizebundle import generate_unique_id
 
 from activity import ViewSourceActivity
 from activity import TARGET_TYPE_TEXT
@@ -1479,7 +1478,7 @@ def main():
         'icon': icon,
         'class': 'activity.VteActivity',
         'bundle_id': ('org.sugarlabs.pippy.%s%d' %
-                      (generate_unique_id(),
+                      (str(uuid.uuid4()).replace('-', ''),
                        int(round(uniform(1000, 9999), 0)))),
         'mime_types': '',
         'extra_info': '',


### PR DESCRIPTION
Fixes: #64 

This pull request addresses [issue #64](https://github.com/sugarlabs/Pippy/issues/64), which reports an ImportError when starting the Pippy activity in a mixed Python 2/3 environment (Python 3 Sugar shell with a Python 2 Pippy bundle). The error occurs due to an import of jarabe.view.customizebundle for the generate_unique_id() function, which is incompatible with Python 2. The issue mentions two jarabe imports, but the current pippy_app.py only references generate_unique_id() in the main() function, indicating prior partial fixes.