### PR TITLE
Remove jarabe Dependencies in icondialog.py (Fixes #64)

### DIFF
--- a/icondialog.py
+++ b/icondialog.py
@@ -20,7 +20,6 @@ import shutil
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
-from jarabe.journal.model import get_documents_path
 from sugar3.activity.activity import get_bundle_path
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.toolbarbox import ToolbarBox
@@ -33,7 +32,7 @@ DEFAULT_ICON = os.path.join(get_bundle_path(), 'activity',
 
 
 def get_document_icons():
-    icons = os.listdir(get_documents_path())
+    icons = os.listdir(os.path.expanduser("~/Documents"))
     icons_ = []
     for icon in icons:
         if icon.endswith('.svg'):
@@ -85,7 +84,7 @@ class IconDialog(Gtk.Window):
         self.set_destroy_with_parent(True)
 
         self.theme = Gtk.IconTheme.get_default()
-        self.theme.append_search_path(get_documents_path())
+        self.theme.append_search_path(os.path.expanduser("~/Documents"))
 
         self._icon = None
         grid = Gtk.Grid()
@@ -162,7 +161,7 @@ class IconDialog(Gtk.Window):
                 continue
             icon_path = os.path.join(get_user_path(), icon + ".svg")
             if not os.path.exists(icon_path):
-                icon_path = os.path.join(get_documents_path(), icon + ".svg")
+                icon_path = os.path.join(os.path.expanduser("~/Documents"), icon + ".svg")
 
             if not os.path.exists(icon_path):
                 icon_path = info.get_filename()


### PR DESCRIPTION
fixes: #64 

Description:

This pull request addresses the jarabe.journal.model import in icondialog.py, one of two jarabe dependencies causing an ImportError in the Pippy activity, as reported in [issue #64](https://github.com/sugarlabs/Pippy/issues/64). The issue occurs in a mixed Python 2/3 environment (Python 3 Sugar shell with Python 2 Pippy bundle), where jarabe modules are unavailable to Python 2. This PR removes the get_documents_path() import and its uses, replacing them with a standard Python alternative to ensure compatibility. The second jarabe import (jarabe.view.customizebundle in pippy_app.py) is addressed in a separate PR (#107 ) as told by mentor.