### PR TITLE
[DMP 2025]: Pippy Debugger Integration

### DIFF
--- a/icons/debug-icon.svg
+++ b/icons/debug-icon.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="64px" height="64px" viewBox="-4.8 -4.8 33.60 33.60" xmlns="http://www.w3.org/2000/svg" fill="#fffafa" stroke="#fffafa" stroke-width="0.00024000000000000003">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M10.94 13.5l-1.32 1.32a3.73 3.73 0 0 0-7.24 0L1.06 13.5 0 14.56l1.72 1.72-.22.22V18H0v1.5h1.5v.08c.077.489.214.966.41 1.42L0 22.94 1.06 24l1.65-1.65A4.308 4.308 0 0 0 6 24a4.31 4.31 0 0 0 3.29-1.65L10.94 24 12 22.94 10.09 21c.198-.464.336-.951.41-1.45v-.1H12V18h-1.5v-1.5l-.22-.22L12 14.56l-1.06-1.06zM6 13.5a2.25 2.25 0 0 1 2.25 2.25h-4.5A2.25 2.25 0 0 1 6 13.5zm3 6a3.33 3.33 0 0 1-3 3 3.33 3.33 0 0 1-3-3v-2.25h6v2.25zm14.76-9.9v1.26L13.5 17.37V15.6l8.5-5.37L9 2v9.46a5.07 5.07 0 0 0-1.5-.72V.63L8.64 0l15.12 9.6z"/>
+</g>
+</svg>

--- a/icons/debug-terminal.svg
+++ b/icons/debug-terminal.svg
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="64px" height="64px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#ffffff">
+
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+
+<g id="SVGRepo_iconCarrier">
+
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.04 1.361l.139-.057H21.32l.14.057 1.178 1.179.057.139V16.82l-.057.14-1.179 1.178-.139.057H14V18a1.99 1.99 0 0 0-.548-1.375h7.673V2.875H7.375v7.282a5.73 5.73 0 0 0-1.571-.164V2.679l.057-.14L7.04 1.362zm9.531 9.452l-2.809 2.8a2 2 0 0 0-.348-.467l-.419-.42 2.236-2.235-3.606-3.694.813-.833 4.133 4.133v.716zM9.62 14.82l1.32-1.32L12 14.56l-1.72 1.72.22.22V18H12v1.45h-1.5v.1a5.888 5.888 0 0 1-.41 1.45L12 22.94 10.94 24l-1.65-1.65A4.308 4.308 0 0 1 6 24a4.31 4.31 0 0 1-3.29-1.65L1.06 24 0 22.94 1.91 21a5.889 5.889 0 0 1-.41-1.42v-.08H0V18h1.5v-1.5l.22-.22L0 14.56l1.06-1.06 1.32 1.32a3.73 3.73 0 0 1 7.24 0zm-2.029-.661A2.25 2.25 0 0 0 3.75 15.75h4.5a2.25 2.25 0 0 0-.659-1.591zm.449 7.38A3.33 3.33 0 0 0 9 19.5v-2.25H3v2.25a3.33 3.33 0 0 0 3 3 3.33 3.33 0 0 0 2.04-.96z"/>
+
+</g>
+
+</svg>

--- a/icons/output-terminal.svg
+++ b/icons/output-terminal.svg
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg xmlns="http://www.w3.org/2000/svg" width="64px" height="64px" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+
+<g id="SVGRepo_iconCarrier"> <path d="M7 11l2-2-2-2"/> <path d="M11 13h4"/> <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/> </g>
+
+</svg>

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -770,6 +770,31 @@ class PippyActivity(ViewSourceActivity):
             GLib.SpawnFlags.DO_NOT_REAP_CHILD,
             None,
             None,)
+            
+    # To extract the source code    
+    def _get_current_code(self):
+        pippy_tmp_dir = '%s/tmp/' % self.get_activity_root()
+        current_file = os.path.join(
+            pippy_tmp_dir,
+            self._source_tabs.get_current_file_name()
+        )
+
+        try:
+            with open(current_file, 'r') as f:
+                return f.read()
+        except Exception as e:
+            print(f"Error reading file {current_file}: {e}")
+            return None
+    
+    def _debug_button_cb(self, button):
+        # Run the code
+        self._go_button_cb(button)
+
+        code = self._get_current_code()
+        if code:
+            print(f"Run and Debug!\n{code}")
+        else:
+            print("No code found to debug.")
 
     def _stop_button_cb(self, button):
         try:

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -445,7 +445,7 @@ class PippyActivity(ViewSourceActivity):
         self._debug_vte.set_scrollback_lines(-1)
 
         self._vte_set_colors('#000000', '#E7E7E7')
-        self._vte_set_debug_colors('#1E1E2E', '#D9E0EE')
+        self._vte_set_debug_colors('#000000', "#D9E0EE")
 
         self._child_exited_handler = None
         self._vte.connect('child_exited', self._child_exited_cb)
@@ -855,7 +855,46 @@ class PippyActivity(ViewSourceActivity):
         except Exception as e:
             print(f"Error reading file {current_file}: {e}")
             return None
-    
+
+    def markdown_parser(self, md: str):
+        lines = md.splitlines()
+        output = []
+        in_code_block = False
+
+        for line in lines:
+            stripped = line.strip()
+
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+
+            if in_code_block:
+                output.append("\033[1m" + line + "\033[0m\r\n")
+                continue
+
+            if stripped.startswith("### "):
+                output.append("\033[1;34;4m" + stripped[4:] + "\033[0m\r\n")
+                continue
+            elif stripped.startswith("## "):
+                output.append("\033[1;34;4m" + stripped[3:] + "\033[0m\r\n")
+                continue
+            elif stripped.startswith("# "):
+                output.append("\033[1;34m;" + stripped[2:] + "\033[0m\r\n")
+                continue
+
+            if stripped.startswith("- "):
+                line = "• " + stripped[2:]
+
+            line = re.sub(r"`([^`]*)`", r"\033[1m\1\033[0m", line)
+
+            line = re.sub(r"\*\*(.*?)\*\*", r"\033[2m\1\033[0m", line)
+
+            line = re.sub(r"(?<!\*)\*(?!\*)(.*?)\*(?!\*)", r"\033[2m\1\033[0m", line)
+
+            output.append(line + "\r\n")
+
+        return ''.join(output)
+
     def _debug_button_cb(self, button):
         # Run the code
         self._go_button_cb(button)
@@ -879,14 +918,11 @@ class PippyActivity(ViewSourceActivity):
 
                 if response.status_code == 200:
                     data = response.json()
-                    tips = data["debug_tips"].replace('\n', '\r\n')\
-                        .replace('**', '') \
-                        .replace('###', '')\
-                        .replace('```python', '\n--- Code ---\n') \
-                        .replace('```', '\n--- End Code ---\n')
-                    print(tips)
+                    debug_tips = data["debug_tips"]
+                    print(debug_tips)
                     self._reset_debug_vte()
-                    GLib.idle_add(self._debug_vte.feed, _(tips).encode())
+                    output = self.markdown_parser(debug_tips)
+                    GLib.idle_add(self._debug_vte.feed, output.encode())
                 else:
                     error_msg = f"Error {response.status_code}: {response.text}"
                     print(error_msg)

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -33,6 +33,7 @@ from random import uniform
 import locale
 import json
 import sys
+import requests
 from shutil import copy2
 from signal import SIGTERM
 from gettext import gettext as _
@@ -793,6 +794,18 @@ class PippyActivity(ViewSourceActivity):
         code = self._get_current_code()
         if code:
             print(f"Run and Debug!\n{code}")
+
+            try:
+                response = requests.post(
+                    "http://192.168.64.1:8000/debug",
+                    json={"code": code},
+                    timeout=50
+                )
+                print(f"API Response: {response.status_code} - {response.text}")
+
+            except requests.RequestException as e:
+                print(f"Failed to send debug request: {e}")
+
         else:
             print("No code found to debug.")
 

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -124,6 +124,8 @@ setup(name='{modulename}',
       )
 """  # This is .format()'ed with the list of the file names.
 
+API_URL = "http://192.168.64.1:8000/debug"
+X_API_KEY = ""
 
 def _has_new_vte_api():
     try:
@@ -850,13 +852,22 @@ class PippyActivity(ViewSourceActivity):
 
         try:
             with open(current_file, 'r') as f:
-                return f.read()
+                lines = f.readlines()
+                filtered_lines = [
+                    line for line in lines
+                    if not (
+                        line.strip().startswith('#!') or
+                        'coding' in line.lower()
+                    )
+                ]
+            return ''.join(filtered_lines)
+
         except Exception as e:
             print(f"Error reading file {current_file}: {e}")
             return None
 
-    def markdown_parser(self, md: str):
-        lines = md.splitlines()
+    def markdown_parser(self, answer):
+        lines = answer.splitlines()
         output = []
         in_code_block = False
 
@@ -871,17 +882,20 @@ class PippyActivity(ViewSourceActivity):
                 output.append("\033[1m" + line + "\033[0m\r\n")
                 continue
 
-            if stripped.startswith("### "):
-                output.append("\033[1;34;4m" + stripped[4:] + "\033[0m\r\n")
+            if stripped.startswith("#### "):
+                output.append("\033[1;34m" + stripped[5:] + "\033[0m\r\n")
+                continue
+            elif stripped.startswith("### "):
+                output.append("\033[1;34m" + stripped[4:] + "\033[0m\r\n")
                 continue
             elif stripped.startswith("## "):
-                output.append("\033[1;34;4m" + stripped[3:] + "\033[0m\r\n")
+                output.append("\033[1;34m" + stripped[3:] + "\033[0m\r\n")
                 continue
             elif stripped.startswith("# "):
-                output.append("\033[1;34m;" + stripped[2:] + "\033[0m\r\n")
+                output.append("\033[1;32;4m" + stripped[2:] + "\033[0m\r\n")
                 continue
 
-            if stripped.startswith("- "):
+            if stripped.startswith("- " or "* "):
                 line = "• " + stripped[2:]
 
             line = re.sub(r"`([^`]*)`", r"\033[1m\1\033[0m", line)
@@ -895,80 +909,73 @@ class PippyActivity(ViewSourceActivity):
         return ''.join(output)
 
     def _debug_button_cb(self, button):
-        # Run the code
-        self._go_button_cb(button)
-
+        self._reset_debug_vte()
         code = self._get_current_code()
         if not code:
-            print("No code found to debug.")
+            self._debug_vte.feed(_("No code found to debug.\r\n").encode())
             return
 
-        print(f"Run and Debug!\n{code}")
-        self._reset_debug_vte()
-        self._debug_vte.feed(_("Analyzing code... Please wait while we generate debugging suggestions.\r\n").encode())
+        self._debug_vte.feed(_("Analyzing code....\r\n").encode())
 
         def debug_task():
             try:
                 response = requests.post(
-                    "http://192.168.64.1:8000/debug",
-                    json={"code": code},
-                    timeout=200
+                    API_URL,
+                    params = {
+                                "code": code,
+                                "context": False
+                            },
+                    headers = {"X-API-Key": X_API_KEY},
                 )
 
                 if response.status_code == 200:
                     data = response.json()
-                    debug_tips = data["debug_tips"]
-                    print(debug_tips)
+                    answer = data["answer"]
                     self._reset_debug_vte()
-                    output = self.markdown_parser(debug_tips)
-                    GLib.idle_add(self._debug_vte.feed, output.encode())
+                    parsed_answer = self.markdown_parser(answer)
+                    GLib.idle_add(self._debug_vte.feed, _(parsed_answer).encode())
                 else:
                     error_msg = f"Error {response.status_code}: {response.text}"
-                    print(error_msg)
                     GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
             except requests.RequestException as e:
                 error_msg = f"Failed to send debug request: {e}"
-                print(error_msg)
                 GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
         threading.Thread(target=debug_task, daemon=True).start()
 
     def _debug_terminal_cb(self, button):
-
+        self._reset_debug_vte()
         code = self._get_current_code()
         if not code:
-            print("No code found to get context.")
+            self._debug_vte.feed(_("No code found to get context.\r\n").encode())
             return
 
-        print(f"Context of \n{code}")
-
-        self._reset_debug_vte()
-        self._debug_vte.feed(_("Getting the context....\r\n").encode())
+        self._debug_vte.feed(_("Analyzing code....\r\n").encode())
 
         def context_task():
             try:
                 response = requests.post(
-                    "http://192.168.64.1:8000/context",
-                    json={"code": code},
-                    timeout=200
+                    API_URL,
+                    params = {
+                                "code": code,
+                                "context": True
+                            },
+                    headers = {"X-API-Key": X_API_KEY},
                 )
 
                 if response.status_code == 200:
                     data = response.json()
-                    context = data["code_context"]
-                    print(context)
+                    answer = data["answer"]
                     self._reset_debug_vte()
-                    ansi_output = self.markdown_parser(context)
-                    GLib.idle_add(self._debug_vte.feed, ansi_output.encode())
+                    parsed_answer = self.markdown_parser(answer)
+                    GLib.idle_add(self._debug_vte.feed, _(parsed_answer).encode())
                 else:
                     error_msg = f"Error {response.status_code}: {response.text}"
-                    print(error_msg)
                     GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
             except requests.RequestException as e:
                 error_msg = f"Failed to send context request: {e}"
-                print(error_msg)
                 GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
         threading.Thread(target=context_task, daemon=True).start()

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -290,6 +290,17 @@ class PippyActivity(ViewSourceActivity):
         button.show()
 
         icon_bw = Gtk.Image()
+        icon_bw.set_from_file(os.path.join(icons_path, 'debug-icon.svg'))
+        icon_bw.show()
+        button = ToolButton(label=_('Run and Debug'))
+        button.props.accelerator = _('<alt>d')
+        button.set_icon_widget(icon_bw)
+        button.set_tooltip(_('Run and Debug'))
+        button.connect('clicked', self._debug_button_cb)
+        actions_toolbar.insert(button, -1)
+        button.show()
+
+        icon_bw = Gtk.Image()
         icon_bw.set_from_file(os.path.join(icons_path, 'stopit_bw.svg'))
         icon_bw.show()
         icon_color = Gtk.Image()

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -34,6 +34,7 @@ import locale
 import json
 import sys
 import requests
+import threading
 from shutil import copy2
 from signal import SIGTERM
 from gettext import gettext as _
@@ -438,15 +439,41 @@ class PippyActivity(ViewSourceActivity):
         self._vte.set_size(30, 5)
         self._vte.set_scrollback_lines(-1)
 
+        self._debug_vte = Vte.Terminal()
+        self._debug_vte.set_encoding('utf-8')
+        self._debug_vte.set_size(30,5)
+        self._debug_vte.set_scrollback_lines(-1)
+
         self._vte_set_colors('#000000', '#E7E7E7')
+        self._vte_set_debug_colors('#1E1E2E', '#D9E0EE')
 
         self._child_exited_handler = None
         self._vte.connect('child_exited', self._child_exited_cb)
         self._vte.connect('drag_data_received', self._vte_drop_cb)
-        self._outbox.pack_start(self._vte, True, True, 0)
+        self._debug_vte.connect('child_exited', self._child_exited_cb)
+        
+        self._debug_vte.feed(_("Please start a debugging session\n").encode())
+        
+        btn_output = Gtk.Button(label="Terminal")
+        btn_debug = Gtk.Button(label="Debug Terminal")
+        btn_output.connect("clicked", lambda w: self._terminal_stack.set_visible_child_name("output"))
+        btn_debug.connect("clicked", lambda w: self._terminal_stack.set_visible_child_name("debug"))
+
+        switch_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        switch_box.pack_start(btn_output, False, False, 0)
+        switch_box.pack_start(btn_debug, False, False, 0)
+
+        self._terminal_stack = Gtk.Stack()
+        self._terminal_stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)
+        self._terminal_stack.add_named(self._vte, "output")
+        self._terminal_stack.add_named(self._debug_vte, "debug")
+
+        self._outbox.pack_start(switch_box, False, False, 0)
+        self._outbox.pack_start(self._terminal_stack, True, True, 0)
 
         outsb = Gtk.Scrollbar(orientation=Gtk.Orientation.VERTICAL)
         outsb.set_adjustment(self._vte.get_vadjustment())
+        outsb.set_adjustment(self._debug_vte.get_vadjustment())
         outsb.show()
         self._outbox.pack_start(outsb, False, False, 0)
 
@@ -470,12 +497,24 @@ class PippyActivity(ViewSourceActivity):
 
         self._vte.set_colors(foreground, background, [])
 
+    def _vte_set_debug_colors(self, bg, fg):
+        if _has_new_vte_api():
+            foreground = Gdk.RGBA(); foreground.parse(bg)
+            background = Gdk.RGBA(); background.parse(fg)
+        else:
+            foreground = Gdk.color_parse(bg)
+            background = Gdk.color_parse(fg)
+
+        self._debug_vte.set_colors(foreground, background, [])
+
     def after_init(self):
         self._outbox.hide()
 
     def _font_size_changed_cb(self, widget, size):
         self._source_tabs.set_font_size(size)
         self._vte.set_font(
+            Pango.FontDescription('Monospace {}'.format(size)))
+        self._debug_vte.set_font(
             Pango.FontDescription('Monospace {}'.format(size)))
 
     def _store_config(self):
@@ -703,6 +742,10 @@ class PippyActivity(ViewSourceActivity):
         self._vte.grab_focus()
         self._vte.feed(b'\x1B[H\x1B[J\x1B[0;39m')
 
+    def _reset_debug_vte(self):
+        self._debug_vte.grab_focus()
+        self._debug_vte.feed(b'\x1B[H\x1B[J\x1B[0;39m')
+
     def __undobutton_cb(self, button):
         text_buffer = self._source_tabs.get_text_buffer()
         if text_buffer.can_undo():
@@ -795,16 +838,29 @@ class PippyActivity(ViewSourceActivity):
         if code:
             print(f"Run and Debug!\n{code}")
 
+            self._reset_debug_vte()
+            self._debug_vte.feed(_("Analyzing code... Please wait while we generate debugging suggestions.\r\n").encode())
+
             try:
                 response = requests.post(
                     "http://192.168.64.1:8000/debug",
                     json={"code": code},
                     timeout=50
                 )
-                print(f"API Response: {response.status_code} - {response.text}")
+
+                if response.status_code == 200:
+                    tips = response.json().get("debug_tips", "")
+                    print(tips)
+                    data = response.text
+                    self._debug_vte.feed(_(data).encode())
+                
+                else:
+                    print(f"Error {response.status_code}: {response.text}")
 
             except requests.RequestException as e:
                 print(f"Failed to send debug request: {e}")
+                msg = f"Failed to send debug request: {e}\r\n"
+                self._debug_vte.feed(_(msg).encode())
 
         else:
             print("No code found to debug.")

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -453,13 +453,39 @@ class PippyActivity(ViewSourceActivity):
         self._debug_vte.connect('child_exited', self._child_exited_cb)
         
         self._debug_vte.feed(_("Please start a debugging session\n").encode())
-        
-        btn_output = Gtk.Button(label="Terminal")
-        btn_debug = Gtk.Button(label="Debug Terminal")
+
+        icon_bw = Gtk.Image()
+        icon_bw.set_from_file(os.path.join(icons_path, 'output-terminal.svg'))
+        icon_bw.show()
+        btn_output = ToolButton(label=_("Terminal"))
+        btn_output.props.accelerator = _('<alt>r')
+        btn_output.set_icon_widget(icon_bw)
+        btn_output.set_tooltip(_("Terminal"))
         btn_output.connect("clicked", lambda w: self._terminal_stack.set_visible_child_name("output"))
+
+        icon_bw = Gtk.Image()
+        icon_bw.set_from_file(os.path.join(icons_path, 'debug-terminal.svg'))
+        icon_bw.show()
+        btn_debug = ToolButton(label=_("Debug Terminal"))
+        btn_debug.props.accelerator = _('<alt>d')
+        btn_debug.set_icon_widget(icon_bw)
+        btn_debug.set_tooltip(_("Debug Terminal"))
         btn_debug.connect("clicked", lambda w: self._terminal_stack.set_visible_child_name("debug"))
 
+        style_provider = Gtk.CssProvider()
+        style_provider.load_from_data(b"""
+        .colored-box {
+        background-color: #282828;
+        }
+        """)
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(),
+            style_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
         switch_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        switch_box.get_style_context().add_class("colored-box")
         switch_box.pack_start(btn_output, False, False, 0)
         switch_box.pack_start(btn_debug, False, False, 0)
 

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -452,8 +452,6 @@ class PippyActivity(ViewSourceActivity):
         self._vte.connect('drag_data_received', self._vte_drop_cb)
         self._debug_vte.connect('child_exited', self._child_exited_cb)
         
-        self._debug_vte.feed(_("Please start a debugging session\n").encode())
-
         icon_bw = Gtk.Image()
         icon_bw.set_from_file(os.path.join(icons_path, 'output-terminal.svg'))
         icon_bw.show()
@@ -470,6 +468,7 @@ class PippyActivity(ViewSourceActivity):
         btn_debug.props.accelerator = _('<alt>d')
         btn_debug.set_icon_widget(icon_bw)
         btn_debug.set_tooltip(_("Debug Terminal"))
+        btn_debug.connect('clicked', self._debug_terminal_cb)
         btn_debug.connect("clicked", lambda w: self._terminal_stack.set_visible_child_name("debug"))
 
         style_provider = Gtk.CssProvider()
@@ -934,6 +933,45 @@ class PippyActivity(ViewSourceActivity):
                 GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
         threading.Thread(target=debug_task, daemon=True).start()
+
+    def _debug_terminal_cb(self, button):
+
+        code = self._get_current_code()
+        if not code:
+            print("No code found to get context.")
+            return
+
+        print(f"Context of \n{code}")
+
+        self._reset_debug_vte()
+        self._debug_vte.feed(_("Getting the context....\r\n").encode())
+
+        def context_task():
+            try:
+                response = requests.post(
+                    "http://192.168.64.1:8000/context",
+                    json={"code": code},
+                    timeout=200
+                )
+
+                if response.status_code == 200:
+                    data = response.json()
+                    context = data["code_context"]
+                    print(context)
+                    self._reset_debug_vte()
+                    ansi_output = self.markdown_parser(context)
+                    GLib.idle_add(self._debug_vte.feed, ansi_output.encode())
+                else:
+                    error_msg = f"Error {response.status_code}: {response.text}"
+                    print(error_msg)
+                    GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
+
+            except requests.RequestException as e:
+                error_msg = f"Failed to send context request: {e}"
+                print(error_msg)
+                GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
+
+        threading.Thread(target=context_task, daemon=True).start()
 
     def _stop_button_cb(self, button):
         try:

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -835,35 +835,43 @@ class PippyActivity(ViewSourceActivity):
         self._go_button_cb(button)
 
         code = self._get_current_code()
-        if code:
-            print(f"Run and Debug!\n{code}")
+        if not code:
+            print("No code found to debug.")
+            return
 
-            self._reset_debug_vte()
-            self._debug_vte.feed(_("Analyzing code... Please wait while we generate debugging suggestions.\r\n").encode())
+        print(f"Run and Debug!\n{code}")
+        self._reset_debug_vte()
+        self._debug_vte.feed(_("Analyzing code... Please wait while we generate debugging suggestions.\r\n").encode())
 
+        def debug_task():
             try:
                 response = requests.post(
                     "http://192.168.64.1:8000/debug",
                     json={"code": code},
-                    timeout=50
+                    timeout=200
                 )
 
                 if response.status_code == 200:
-                    tips = response.json().get("debug_tips", "")
+                    data = response.json()
+                    tips = data["debug_tips"].replace('\n', '\r\n')\
+                        .replace('**', '') \
+                        .replace('###', '')\
+                        .replace('```python', '\n--- Code ---\n') \
+                        .replace('```', '\n--- End Code ---\n')
                     print(tips)
-                    data = response.text
-                    self._debug_vte.feed(_(data).encode())
-                
+                    self._reset_debug_vte()
+                    GLib.idle_add(self._debug_vte.feed, _(tips).encode())
                 else:
-                    print(f"Error {response.status_code}: {response.text}")
+                    error_msg = f"Error {response.status_code}: {response.text}"
+                    print(error_msg)
+                    GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
             except requests.RequestException as e:
-                print(f"Failed to send debug request: {e}")
-                msg = f"Failed to send debug request: {e}\r\n"
-                self._debug_vte.feed(_(msg).encode())
+                error_msg = f"Failed to send debug request: {e}"
+                print(error_msg)
+                GLib.idle_add(self._debug_vte.feed, _(error_msg + "\r\n").encode())
 
-        else:
-            print("No code found to debug.")
+        threading.Thread(target=debug_task, daemon=True).start()
 
     def _stop_button_cb(self, button):
         try:


### PR DESCRIPTION
## Overview  
This PR introduces the **Pippy Debugger**, bringing LLM-powered debugging support into the Pippy activity. Kids can now send their code for analysis and view helpful debugging suggestion.  

## Key Features  
- **Dedicated Debug Terminal**  
  A new terminal is added alongside the output terminal to show debugging feedback in a clear, separate space.  

- **One-Click Debugging**  
  A toolbar button with a new debug icon lets users easily run their code and request debugging help.  

- **Readable AI Feedback**  
  Debugging tips are displayed with proper formatting like including headings, lists, and code blocks which makes the suggestions easier to follow.  

- **Responsive Experience**  
  Debugging requests no longer freeze the UI, ensuring a smooth experience while results are being fetched.  

- **Cleaner Code Context**  
  Only the relevant code is sent for debugging (ignoring boilerplate like shebang lines), so feedback is more focused.  

## UI Previews  
- ### Updated Pippy UI
<img width="1470" height="889" alt="Pippy-UI01" src="https://github.com/user-attachments/assets/9f25bd67-d19a-4742-9ded-7709fc0371f3" />

- ### Debugger's output
1. 
<img width="1470" height="887" alt="Pippy-UI02" src="https://github.com/user-attachments/assets/13aa330c-e7b7-44d3-9cef-dd2cda1c2f7e" />

2. 
<img width="1470" height="887" alt="Pippy-UI03" src="https://github.com/user-attachments/assets/0d6dd4b6-8806-4e37-a24a-f9efd8578896" />

## ToDO
- [ ] Update the `API_URL` with sugarAI URL after merging of PR https://github.com/sugarlabs/sugar-ai/pull/28 .
- [ ] Handling of `API_KEY`. 

## Added dependencies  
- Uses the **standard library** `threading` module for background tasks.  
- Introduces the **third-party** `requests` library for making API calls.  

## Notes for Reviewer
@chimosky as you’ve previously reviewed most of this code, could you please review it again.

## Project Reference  
This work is part of **DMP 2025** (#95).  
